### PR TITLE
Correct template tab name typo

### DIFF
--- a/web/js/producer.js
+++ b/web/js/producer.js
@@ -440,7 +440,7 @@ function init(){
             var templates = [
                 {"name": "Template 1", "template": ""},
                 {"name": "Template 2", "template": ""},
-                {"name": "Template 4", "template": ""},
+                {"name": "Template 3", "template": ""},
                 {"name": "Template 4", "template": ""},
                 {"name": "Template 5", "template": ""}
             ];


### PR DESCRIPTION
"Template 4" was duplicated, for what should have been "Template 3" and "Template 4".