### PR TITLE
Added implementation of address.nearbyGPSCoordinate from faker.js

### DIFF
--- a/web/js/faker.js
+++ b/web/js/faker.js
@@ -225,6 +225,61 @@ function Address (faker) {
       return (faker.random.number(360 * 10000) / 10000.0 - 180.0).toFixed(4);
   }
   
+  /**
+   * nearbyGPSCoordinate
+   *
+   * @method faker.address.nearbyGPSCoordinate
+   * @param {object} object
+   */
+  this.nearbyGPSCoordinate = function(object) {
+      function randomFloat(min, max) {
+        return Math.random() * (max-min) + min;
+      }
+      function degreesToRadians(degrees) {
+        return degrees * (Math.PI/180.0);
+      }
+      function radiansToDegrees(radians) {
+        return radians * (180.0/Math.PI);
+      }
+      function kilometersToMiles(miles) {
+        return miles * 0.621371;
+      }
+      function coordinateWithOffset(coordinate, bearing, distance, isMetric) {
+        var R = 6378.137; // Radius of the Earth (http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html)
+        var d = isMetric ? distance : kilometersToMiles(distance); // Distance in km
+
+        var lat1 = degreesToRadians(coordinate[0]); //Current lat point converted to radians
+        var lon1 = degreesToRadians(coordinate[1]); //Current long point converted to radians
+
+        var lat2 = Math.asin(Math.sin(lat1) * Math.cos(d/R) +
+            Math.cos(lat1) * Math.sin(d/R) * Math.cos(bearing));
+
+        var lon2 = lon1 + Math.atan2(
+            Math.sin(bearing) * Math.sin(d/R) * Math.cos(lat1),
+            Math.cos(d/R) - Math.sin(lat1) * Math.sin(lat2));
+
+        // Keep longitude in range [-180, 180]
+        if (lon2 > degreesToRadians(180)) {
+            lon2 = lon2 - degreesToRadians(360);
+        } else if (lon2 < degreesToRadians(-180)) {
+            lon2 = lon2 + degreesToRadians(360);
+        }
+
+        return [radiansToDegrees(lat2), radiansToDegrees(lon2)];
+      }
+
+      coordinate = object.coordinate || [faker.address.latitude(), faker.address.longitude()];
+      radius = object.radius || 10.0;
+      isMetric = object.isMetric || false;
+
+      // TODO: implement either a gaussian/uniform distribution of points in cicular region.
+      // Possibly include param to function that allows user to choose between distributions.
+
+      // This approach will likely result in a higher density of points near the center.
+      var randomCoord = coordinateWithOffset(coordinate, degreesToRadians(Math.random() * 360.0), radius, isMetric);
+      return [randomCoord[0].toFixed(4), randomCoord[1].toFixed(4)];
+}
+  
   return this;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implemented address.nearbyGPSCoordinate from faker (https://github.com/Marak/faker.js/blob/91dc8a3372426bc691be56153b33e81a16459f49/lib/address.js). Helpful when mocking moving GPS sensors, other location based information. To invoke: {{address.nearbyGPSCoordinate({"coordinate": [61.2181, -149.9000], "radius": 50})}}


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
