### PR TITLE
Added Permissions boundary support for role creation

### DIFF
--- a/setup/cognito-setup.yaml
+++ b/setup/cognito-setup.yaml
@@ -14,6 +14,10 @@ Parameters:
     NoEcho: true
     AllowedPattern: "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,}$"
     ConstraintDescription: " must be at least 6 alpha-numeric characters, and contain at least one number"
+  PermissionsBoundaryArn:
+    Description: OPTIONAL - IAM Permissions Boundary Policy ARN to attach to new IAM Roles
+    Type: String
+    Default: ""
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -23,6 +27,16 @@ Metadata:
         Parameters:
           - Username
           - Password
+      - Label:
+          default: Optional / Advanced Parameters (OK to ignore)
+        Parameters:
+          - PermissionsBoundaryArn
+
+Conditions:
+  SetPermissionsBoundary: !Not
+    - !Equals
+      - !Ref PermissionsBoundaryArn
+      - ""
 
 Mappings:
   PrincipalMap:
@@ -53,6 +67,10 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - sts:AssumeRole
+      PermissionsBoundary: !If
+        - SetPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: BootStrapLambdaSetup
@@ -185,6 +203,10 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - "sts:AssumeRole"
+      PermissionsBoundary: !If
+        - SetPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: SetupCognitoLambda
@@ -249,6 +271,10 @@ Resources:
                 - !FindInMap [PrincipalMap, !Ref AWS::Partition, cognito]
             Action:
               - "sts:AssumeRoleWithWebIdentity"
+      PermissionsBoundary: !If
+        - SetPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: AllowStreaming
@@ -289,6 +315,10 @@ Resources:
                 - !FindInMap [PrincipalMap, !Ref AWS::Partition, cognito]
             Action:
               - "sts:AssumeRoleWithWebIdentity"
+      PermissionsBoundary: !If
+        - SetPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: DenyAll


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the ability to optional provide the ARN of a Permissions Boundary policy to use during IAM role creations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
