### PR TITLE
Create multiple sensors

### DIFF
--- a/setup/cognito-setup.yaml
+++ b/setup/cognito-setup.yaml
@@ -116,7 +116,7 @@ Resources:
               http = urllib3.PoolManager()
               rsc_props = event['ResourceProperties']
 
-              bucket = rsc_props['StagingS3BucketSensor1Name']
+              bucket = rsc_props['StagingS3BucketName']
               url_to_fetch = rsc_props['UrlLambdaZipToStage']
               filename_key = rsc_props['FilenameKey']
               expected_sha = rsc_props['Expected512Sha']
@@ -162,7 +162,7 @@ Resources:
     Type: "Custom::BootstrapStagingLambdaFunc"
     Properties:
       ServiceToken: !GetAtt StagingLambdaFunc.Arn
-      StagingS3BucketSensor1Name: !Ref StagingS3Bucket
+      StagingS3BucketName: !Ref StagingS3Bucket
       UrlLambdaZipToStage: "https://github.com/awslabs/amazon-kinesis-data-generator/blob/mainline/setup/datagen-cognito-setup.zip?raw=true"
       FilenameKey: "datagen-cognito-setup.zip"
       Expected512Sha: "bbe80f52ec7a246c065069f2bb0112a1a968472e6b48946ab88d73e5284787cd56acbd1d7adaa07a8120f3e1bd8d6644b96d18d7f0d7a2e60013d77b00d07eaa"

--- a/setup/cognito-setup.yaml
+++ b/setup/cognito-setup.yaml
@@ -14,10 +14,9 @@ Parameters:
     NoEcho: true
     AllowedPattern: "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,}$"
     ConstraintDescription: " must be at least 6 alpha-numeric characters, and contain at least one number"
-  PermissionsBoundaryArn:
-    Description: OPTIONAL - IAM Permissions Boundary Policy ARN to attach to new IAM Roles
-    Type: String
-    Default: ""
+  SensorNumber:
+    Description: The number identifier for the sensor.
+    Type: Number
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -28,15 +27,9 @@ Metadata:
           - Username
           - Password
       - Label:
-          default: Optional / Advanced Parameters (OK to ignore)
+          default: Sensor Configuration
         Parameters:
-          - PermissionsBoundaryArn
-
-Conditions:
-  SetPermissionsBoundary: !Not
-    - !Equals
-      - !Ref PermissionsBoundaryArn
-      - ""
+          - SensorNumber
 
 Mappings:
   PrincipalMap:
@@ -51,7 +44,7 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
     Properties:
-      Name: KinesisDataGeneratorUser
+      Name: !Sub 'Sensor_${SensorNumber}_KinesisDataGeneratorUser'
       Description: Secret for the Cognito User for the Kinesis Data Generator
       SecretString: !Sub '{ "username": "${Username}", "password": "${Password}" }'
 
@@ -67,13 +60,9 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - sts:AssumeRole
-      PermissionsBoundary: !If
-        - SetPermissionsBoundary
-        - !Ref PermissionsBoundaryArn
-        - !Ref AWS::NoValue
       Path: /
       Policies:
-        - PolicyName: BootStrapLambdaSetup
+        - PolicyName: !Sub 'Sensor_${SensorNumber}_BootStrapLambdaSetup'
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -93,6 +82,7 @@ Resources:
   StagingS3Bucket:
     Type: "AWS::S3::Bucket"
     Properties:
+      BucketName: !Sub 'sensor-${SensorNumber}-data-storage'
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -102,7 +92,7 @@ Resources:
     Type: "AWS::Lambda::Function"
     DependsOn: StagingS3Bucket
     Properties:
-      FunctionName: bootstrapStagingLambdaSetup
+      FunctionName: !Sub 'Sensor_${SensorNumber}_bootstrapStagingLambdaSetup'
       Description: Staging Lambda to pull the zip dependency from GitHub to build the "real" setup function
       Role: !GetAtt StagingLambdaRole.Arn
       Runtime: python3.9
@@ -126,7 +116,7 @@ Resources:
               http = urllib3.PoolManager()
               rsc_props = event['ResourceProperties']
 
-              bucket = rsc_props['StagingS3BucketName']
+              bucket = rsc_props['StagingS3BucketSensor1Name']
               url_to_fetch = rsc_props['UrlLambdaZipToStage']
               filename_key = rsc_props['FilenameKey']
               expected_sha = rsc_props['Expected512Sha']
@@ -172,7 +162,7 @@ Resources:
     Type: "Custom::BootstrapStagingLambdaFunc"
     Properties:
       ServiceToken: !GetAtt StagingLambdaFunc.Arn
-      StagingS3BucketName: !Ref StagingS3Bucket
+      StagingS3BucketSensor1Name: !Ref StagingS3Bucket
       UrlLambdaZipToStage: "https://github.com/awslabs/amazon-kinesis-data-generator/blob/mainline/setup/datagen-cognito-setup.zip?raw=true"
       FilenameKey: "datagen-cognito-setup.zip"
       Expected512Sha: "bbe80f52ec7a246c065069f2bb0112a1a968472e6b48946ab88d73e5284787cd56acbd1d7adaa07a8120f3e1bd8d6644b96d18d7f0d7a2e60013d77b00d07eaa"
@@ -185,7 +175,7 @@ Resources:
         S3Bucket: !Ref StagingS3Bucket
         S3Key: datagen-cognito-setup.zip
       Description: "Creates a Cognito User Pool, Identity Pool, and a User.  Returns IDs to be used in the Kinesis Data Generator."
-      FunctionName: KinesisDataGeneratorCognitoSetup
+      FunctionName: !Sub 'Sensor_${SensorNumber}_KinesisDataGeneratorCognitoSetup'
       Handler: createCognitoPool.createPoolAndUser
       Role: !GetAtt SetupLambdaExecutionRole.Arn
       Runtime: nodejs18.x
@@ -203,10 +193,6 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - "sts:AssumeRole"
-      PermissionsBoundary: !If
-        - SetPermissionsBoundary
-        - !Ref PermissionsBoundaryArn
-        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: SetupCognitoLambda
@@ -271,10 +257,6 @@ Resources:
                 - !FindInMap [PrincipalMap, !Ref AWS::Partition, cognito]
             Action:
               - "sts:AssumeRoleWithWebIdentity"
-      PermissionsBoundary: !If
-        - SetPermissionsBoundary
-        - !Ref PermissionsBoundaryArn
-        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: AllowStreaming
@@ -315,10 +297,6 @@ Resources:
                 - !FindInMap [PrincipalMap, !Ref AWS::Partition, cognito]
             Action:
               - "sts:AssumeRoleWithWebIdentity"
-      PermissionsBoundary: !If
-        - SetPermissionsBoundary
-        - !Ref PermissionsBoundaryArn
-        - !Ref AWS::NoValue
       Path: /
       Policies:
         - PolicyName: DenyAll


### PR DESCRIPTION
Non specific issue

Update cognito-setup.yaml allows users to create multiple Generators using the same CloudFormation Stack. It uses the new parameter SensorNumber.

