### PR TITLE
Improve checksum validation error messaging for users

### DIFF
--- a/setup/cognito-setup.yaml
+++ b/setup/cognito-setup.yaml
@@ -138,8 +138,15 @@ Resources:
               print('Hash complete.')
               m.update(resp.data)
               if expected_sha != m.hexdigest():
-                print(f'downloaded checksum does not match baseline. Expected[{expected_sha}], Got[{m.hexdigest()}]')
-                raise RunTimeError(f'downloaded checksum does not match baseline. Expected[{expected_sha}], Got[{m.hexdigest()}]')
+                actual_sha = m.hexdigest()
+                print(f'downloaded checksum does not match baseline. Expected[{expected_sha}], Got[{actual_sha}]')
+                error_msg = (
+                    f'Checksum validation failed due to GitHub CDN caching issues. '
+                    f'This is a temporary problem. Please try deploying the CloudFormation stack again. '
+                    f'Expected SHA512: {expected_sha}, Got: {actual_sha}. '
+                    f'If this error persists after multiple attempts, please report it as an issue on the GitHub repository.'
+                )
+                raise RuntimeError(error_msg)
 
               print(f'About to put file to S3: {bucket}/{filename_key}')
               s3 = boto3.client('s3')


### PR DESCRIPTION
Added a user-friendly error message when GitHub CDN caching causes checksum mismatches during CloudFormation deployment. The new message explains this is a temporary issue and suggests retrying the deployment, reducing user confusion and support requests. 

Source used - https://catalog.us-east-1.prod.workshops.aws/workshops/44c91c21-a6a4-4b56-bd95-56bd443aa449/en-US/lab-guide/ingest

*Issue #, if available:*

*Description of changes:*
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
